### PR TITLE
Add constructor argument for patient ID

### DIFF
--- a/tumor_board_agent/tumor_board_agent.py
+++ b/tumor_board_agent/tumor_board_agent.py
@@ -90,10 +90,13 @@ def get_census_gene_sets():
 
 class TumorBoardAgent:
 
-    def __init__(self):
+    def __init__(self, patient_id=None):
         self.tumor_board_report = None
         self.sorted_results = None
         self.pc_evidences = None
+        self.patient_id = patient_id
+        if patient_id is not None:
+            self.create_tumor_board_report(self.patient_id)
 
     def create_tumor_board_report(self, patient_id):
         variants = None


### PR DESCRIPTION
This PR adds patient_id as an optional argument for the TumorBoardAgent.